### PR TITLE
Fix boolean parsing.

### DIFF
--- a/server.go
+++ b/server.go
@@ -322,7 +322,7 @@ func yamlToCluster(clusterName string, yaml map[string]interface{}) (grange.Clus
 		case int:
 			c[key] = []string{fmt.Sprintf("%d", value.(int))}
 		case bool:
-			c[key] = []string{fmt.Sprintf("%s", value.(bool))}
+			c[key] = []string{fmt.Sprintf("%t", value.(bool))}
 		case []interface{}:
 			result := []string{}
 


### PR DESCRIPTION
I'm sure this must have worked at some point, maybe fmt changed in a
recent go version? I've never seen %t before.

Fixes #8.

@drcapulet @jeeyoungk 